### PR TITLE
Refactor estimators for simplicity and make tests more modular

### DIFF
--- a/src/sklearn_knn/_base.py
+++ b/src/sklearn_knn/_base.py
@@ -1,11 +1,7 @@
-from abc import abstractmethod
-
 import numpy as np
 
-from sklearn.base import BaseEstimator
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.preprocessing import StandardScaler
-from sklearn.utils.validation import check_X_y
 
 
 class IDNeighborsClassifier(KNeighborsClassifier):
@@ -13,7 +9,6 @@ class IDNeighborsClassifier(KNeighborsClassifier):
     Specialized KNeighborsClassifier where labels
     are IDs for samples and not classes
     """
-
     def kneighbor_ids(self, X=None, n_neighbors=None):
         neigh_ind = super().kneighbors(X, n_neighbors, False)
         return self.classes_[self._y[neigh_ind]]
@@ -24,49 +19,3 @@ class MyStandardScaler(StandardScaler):
         sc = super().fit(X, y, sample_weight)
         sc.scale_ = np.std(X, axis=0, ddof=1)
         return sc
-
-
-class KnnPipeline(BaseEstimator):
-    def __init__(
-        self,
-        n_neighbors=5,
-        *,
-        weights="distance",
-    ):
-        self.n_neighbors = n_neighbors
-        self.weights = weights
-
-    @abstractmethod
-    def _get_pipeline(self):
-        raise NotImplementedError()
-
-    def fit(self, X, y, **fit_params):
-        if not hasattr(self, "_pipeline"):
-            self._pipeline = self._get_pipeline()
-        X, y = check_X_y(X, y)
-        self.is_fitted_ = True
-        self.n_features_in_ = X.shape[1]
-        self._pipeline.fit(X, y, **fit_params)
-        return self
-
-    def predict(self, X):
-        return self._pipeline.predict(X)
-
-    def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
-        if X is None:
-            return self._pipeline[-1].kneighbors(
-                n_neighbors=n_neighbors, return_distance=return_distance
-            )
-        return self._pipeline[-1].kneighbors(
-            X=self._pipeline[:-1].transform(X),
-            n_neighbors=n_neighbors,
-            return_distance=return_distance,
-        )
-
-    def kneighbor_ids(self, X=None, n_neighbors=None):
-        if X is None:
-            return self._pipeline[-1].kneighbor_ids(n_neighbors=n_neighbors)
-        return self._pipeline[-1].kneighbor_ids(
-            X=self._pipeline[:-1].transform(X),
-            n_neighbors=n_neighbors,
-        )

--- a/src/sklearn_knn/_euclidean.py
+++ b/src/sklearn_knn/_euclidean.py
@@ -1,14 +1,12 @@
-from sklearn.pipeline import Pipeline
-
-from ._base import MyStandardScaler, IDNeighborsClassifier, KnnPipeline
+from ._base import MyStandardScaler, IDNeighborsClassifier
 
 
-class Euclidean(KnnPipeline):
-    def _get_pipeline(self):
-        scaler = MyStandardScaler()
-        classifier = IDNeighborsClassifier(
-            n_neighbors=self.n_neighbors,
-            weights=self.weights,
-        )
-        steps = [("scaler", scaler), ("classifier", classifier)]
-        return Pipeline(steps)
+class Euclidean(IDNeighborsClassifier):
+    """Normalized KNN"""
+    def fit(self, X, y):
+        X = MyStandardScaler().fit_transform(X)
+        return super().fit(X, y)
+    
+    def predict(self, X):
+        X = MyStandardScaler().fit_transform(X)
+        return super().predict(X)

--- a/src/sklearn_knn/_raw.py
+++ b/src/sklearn_knn/_raw.py
@@ -1,13 +1,6 @@
-from sklearn.pipeline import Pipeline
-
-from ._base import IDNeighborsClassifier, KnnPipeline
+from ._base import IDNeighborsClassifier
 
 
-class Raw(KnnPipeline):
-    def _get_pipeline(self):
-        classifier = IDNeighborsClassifier(
-            n_neighbors=self.n_neighbors,
-            weights=self.weights,
-        )
-        steps = [("classifier", classifier)]
-        return Pipeline(steps)
+class Raw(IDNeighborsClassifier):
+    """Alias for IDNeighborsClassifier"""
+    pass

--- a/src/sklearn_knn/original/_gnn.py
+++ b/src/sklearn_knn/original/_gnn.py
@@ -1,15 +1,13 @@
-from sklearn.pipeline import Pipeline
-
-from .._base import IDNeighborsClassifier, KnnPipeline
+from .._base import IDNeighborsClassifier
 from ._cca_transformer import CCATransformer
 
 
-class GNN(KnnPipeline):
-    def _get_pipeline(self):
-        transformer = CCATransformer()
-        classifier = IDNeighborsClassifier(
-            n_neighbors=self.n_neighbors,
-            weights=self.weights,
-        )
-        steps = [("transform", transformer), ("classifier", classifier)]
-        return Pipeline(steps)
+class GNN(IDNeighborsClassifier):
+    """Normalized KNN"""
+    def fit(self, X, y, cca_params=None):
+        X = CCATransformer().fit_transform(X, **cca_params)
+        return super().fit(X, y)
+    
+    def predict(self, X, cca_params=None):
+        X = CCATransformer().fit_transform(X, **cca_params)
+        return super().predict(X)


### PR DESCRIPTION
Hey Matt, I'm mostly opening this just to share some ideas I had around simplifying the estimators and reducing some duplication. It's definitely possible I removed some flexibility that we'll need further down the road, so keep an eye out for that. The changes are broadly described below.

By making all the estimators subclass `IDNeighborsClassifier` instead of `KnnPipeline`, we're able to a) access `kneighbors` and `kneighbor_ids` without having to duplicate them in `KnnPipeline`, and b) pass any classifier kwargs (like `n_jobs`) straight through the constructor. That took away the ability to automatically run pipelines, so for now I just manually run the necessary transformers within each estimator. I think it might be worth making something like a `PipelineEstimatorMixin` class that we can add as another superclass to our estimators so we don't have to re-implement `fit` and `predict` for every estimator, but I thought I'd just keep it simple for now. 

I also did some cleanup in the tests, mostly so that I could swap out the raw asserts for the numpy testing functions, which provide some helpful feedback about how the values compare. Currently we're still passing all the neighbor ID tests. I just noticed we're now failing the `Raw` distance test which we weren't before, but it looks like that's just due to the difference in precision between `assert_array_almost_equal` and `all_close`, which is [adjustable with `decimal`](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_almost_equal.html).

As I said, the goal of this PR is mostly just to get your feedback on some ideas that we might implement, so I'm not sure if it will be worth merging or just pulling out the pieces you like. 