### PR TITLE
Subclass estimators from KNeighborsRegressor

### DIFF
--- a/src/sklearn_knn/_base.py
+++ b/src/sklearn_knn/_base.py
@@ -1,24 +1,19 @@
 import numpy as np
-from sklearn.neighbors import KNeighborsClassifier
+from sklearn.neighbors import KNeighborsRegressor
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.validation import check_is_fitted
 
 
-class IDNeighborsClassifier(KNeighborsClassifier):
+class IDNeighborsRegressor(KNeighborsRegressor):
     """
-    Specialized KNeighborsClassifier where labels
-    are IDs for samples and not classes
+    Placeholder class for implementing plot ID access.
     """
 
-    def kneighbor_ids(self, X=None, n_neighbors=None):
-        neigh_ind = super().kneighbors(X, n_neighbors, False)
-        return self.classes_[self._y[neigh_ind]]
 
-
-class TransformedKNeighborsMixin(KNeighborsClassifier):
+class TransformedKNeighborsMixin(KNeighborsRegressor):
     """
-    Mixin for KNeighbors classifiers that store a `transform_` during fitting
-    (e.g. GNN).
+    Mixin for KNeighbors regressors that store a `transform_` during fitting (e.g.
+    GNN).
     """
 
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True):

--- a/src/sklearn_knn/_euclidean.py
+++ b/src/sklearn_knn/_euclidean.py
@@ -1,9 +1,9 @@
 from sklearn.utils.validation import check_is_fitted
 
-from ._base import IDNeighborsClassifier, MyStandardScaler, TransformedKNeighborsMixin
+from ._base import IDNeighborsRegressor, MyStandardScaler, TransformedKNeighborsMixin
 
 
-class Euclidean(IDNeighborsClassifier, TransformedKNeighborsMixin):
+class Euclidean(IDNeighborsRegressor, TransformedKNeighborsMixin):
     def fit(self, X, y):
         self.transform_ = MyStandardScaler().fit(X)
         X = self.transform_.transform(X)

--- a/src/sklearn_knn/_gnn.py
+++ b/src/sklearn_knn/_gnn.py
@@ -1,10 +1,10 @@
 from sklearn.utils.validation import check_is_fitted
 
-from ._base import IDNeighborsClassifier, TransformedKNeighborsMixin
+from ._base import IDNeighborsRegressor, TransformedKNeighborsMixin
 from .transformers._cca_transformer import CCATransformer
 
 
-class GNN(IDNeighborsClassifier, TransformedKNeighborsMixin):
+class GNN(IDNeighborsRegressor, TransformedKNeighborsMixin):
     def fit(self, X, y, spp=None):
         self.transform_ = CCATransformer().fit(X, y=y, spp=spp)
         X = self.transform_.transform(X)

--- a/src/sklearn_knn/_mahalanobis.py
+++ b/src/sklearn_knn/_mahalanobis.py
@@ -1,10 +1,10 @@
 from sklearn.utils.validation import check_is_fitted
 
-from ._base import IDNeighborsClassifier, TransformedKNeighborsMixin
+from ._base import IDNeighborsRegressor, TransformedKNeighborsMixin
 from .transformers._mahalanobis_transformer import MahalanobisTransformer
 
 
-class Mahalanobis(IDNeighborsClassifier, TransformedKNeighborsMixin):
+class Mahalanobis(IDNeighborsRegressor, TransformedKNeighborsMixin):
     def fit(self, X, y):
         self.transform_ = MahalanobisTransformer().fit(X)
         X = self.transform_.transform(X)

--- a/src/sklearn_knn/_raw.py
+++ b/src/sklearn_knn/_raw.py
@@ -1,5 +1,5 @@
-from ._base import IDNeighborsClassifier
+from ._base import IDNeighborsRegressor
 
 
-class Raw(IDNeighborsClassifier):
+class Raw(IDNeighborsRegressor):
     pass

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -6,12 +6,12 @@ import pytest
 from sklearn.utils.validation import NotFittedError
 
 from sklearn_knn import GNN, Euclidean, Mahalanobis, Raw
-from sklearn_knn._base import IDNeighborsClassifier
+from sklearn_knn._base import IDNeighborsRegressor
 
 
-def get_kneighbor_estimator_instances() -> List[IDNeighborsClassifier]:
+def get_kneighbor_estimator_instances() -> List[IDNeighborsRegressor]:
     """
-    Return instances of all supported IDNeighborsClassifier estimators.
+    Return instances of all supported IDNeighborsRegressor estimators.
     """
     return [
         Raw(),
@@ -37,14 +37,14 @@ def test_estimators_raise_notfitted_kneighbors(estimator, moscow_euclidean):
 
 
 @pytest.mark.parametrize("estimator", get_kneighbor_estimator_instances())
-def test_estimators_raise_notfitted_kneighbor_ids(estimator, moscow_euclidean):
-    """Attempting to call kneighbor_ids on an unfitted estimator should raise."""
-    with pytest.raises(NotFittedError):
-        estimator.kneighbor_ids(moscow_euclidean.X)
-
-
-@pytest.mark.parametrize("estimator", get_kneighbor_estimator_instances())
 def test_estimators_raise_notfitted_predict(estimator, moscow_euclidean):
     """Attempting to call predict on an unfitted estimator should raise."""
     with pytest.raises(NotFittedError):
         estimator.predict(moscow_euclidean.X)
+
+
+@pytest.mark.parametrize("estimator", get_kneighbor_estimator_instances())
+def test_estimators_support_continuous_multioutput(estimator, moscow_euclidean):
+    """All estimators should fit and predict continuous multioutput data."""
+    estimator.fit(moscow_euclidean.X, moscow_euclidean.y)
+    estimator.predict(moscow_euclidean.X)

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_array_almost_equal, assert_array_equal
+from numpy.testing import assert_array_almost_equal
 from sklearn.model_selection import train_test_split
 
 from sklearn_knn import GNN, Euclidean, Mahalanobis, Raw
@@ -10,16 +10,14 @@ def test_moscow_raw(moscow_raw):
     )
     clf = Raw(n_neighbors=5).fit(X_train, y_train)
 
-    dist, _ = clf.kneighbors()
-    nn = clf.kneighbor_ids()
+    dist, nn = clf.kneighbors()
 
-    assert_array_equal(nn, moscow_raw.ref_neighbors)
+    # assert_array_equal(nn, moscow_raw.ref_neighbors)
     assert_array_almost_equal(dist, moscow_raw.ref_distances, decimal=3)
 
-    dist, _ = clf.kneighbors(X_test)
-    nn = clf.kneighbor_ids(X_test)
+    dist, nn = clf.kneighbors(X_test)
 
-    assert_array_equal(nn, moscow_raw.trg_neighbors)
+    # assert_array_equal(nn, moscow_raw.trg_neighbors)
     assert_array_almost_equal(dist, moscow_raw.trg_distances, decimal=3)
 
 
@@ -29,16 +27,14 @@ def test_moscow_euclidean(moscow_euclidean):
     )
     clf = Euclidean(n_neighbors=5).fit(X_train, y_train)
 
-    dist, _ = clf.kneighbors()
-    nn = clf.kneighbor_ids()
+    dist, nn = clf.kneighbors()
 
-    assert_array_equal(nn, moscow_euclidean.ref_neighbors)
+    # assert_array_equal(nn, moscow_euclidean.ref_neighbors)
     assert_array_almost_equal(dist, moscow_euclidean.ref_distances, decimal=3)
 
-    dist, _ = clf.kneighbors(X_test)
-    nn = clf.kneighbor_ids(X_test)
+    dist, nn = clf.kneighbors(X_test)
 
-    assert_array_equal(nn, moscow_euclidean.trg_neighbors)
+    # assert_array_equal(nn, moscow_euclidean.trg_neighbors)
     assert_array_almost_equal(dist, moscow_euclidean.trg_distances, decimal=3)
 
 
@@ -48,16 +44,14 @@ def test_moscow_mahalanobis(moscow_mahalanobis):
     )
     clf = Mahalanobis(n_neighbors=5).fit(X_train, y_train)
 
-    dist, _ = clf.kneighbors()
-    nn = clf.kneighbor_ids()
+    dist, nn = clf.kneighbors()
 
-    assert_array_equal(nn, moscow_mahalanobis.ref_neighbors)
+    # assert_array_equal(nn, moscow_mahalanobis.ref_neighbors)
     assert_array_almost_equal(dist, moscow_mahalanobis.ref_distances, decimal=3)
 
-    dist, _ = clf.kneighbors(X_test)
-    nn = clf.kneighbor_ids(X_test)
+    dist, nn = clf.kneighbors(X_test)
 
-    assert_array_equal(nn, moscow_mahalanobis.trg_neighbors)
+    # assert_array_equal(nn, moscow_mahalanobis.trg_neighbors)
     assert_array_almost_equal(dist, moscow_mahalanobis.trg_distances, decimal=3)
 
 
@@ -67,14 +61,12 @@ def test_moscow_gnn(moscow_gnn):
     )
     clf = GNN(n_neighbors=5).fit(X_train, y_train, spp=y_spp)
 
-    dist, _ = clf.kneighbors()
-    nn = clf.kneighbor_ids()
+    dist, nn = clf.kneighbors()
 
-    assert_array_equal(nn, moscow_gnn.ref_neighbors)
+    # assert_array_equal(nn, moscow_gnn.ref_neighbors)
     assert_array_almost_equal(dist, moscow_gnn.ref_distances, decimal=3)
 
-    dist, _ = clf.kneighbors(X_test)
-    nn = clf.kneighbor_ids(X_test)
+    dist, nn = clf.kneighbors(X_test)
 
-    assert_array_equal(nn, moscow_gnn.trg_neighbors)
+    # assert_array_equal(nn, moscow_gnn.trg_neighbors)
     assert_array_almost_equal(dist, moscow_gnn.trg_distances, decimal=3)


### PR DESCRIPTION
This would close #13 by making all estimators subclass `KNeighborsRegressor` instead of `KNeighborsClassifier`, allowing us to fit and predict continuous multioutput data. It also removes the `kneighbor_ids` method following the discussion in #2, but leaves the (renamed) `IDNeighborsRegressor` in place while we figure out whether we need that. 

All of the tests against neighbor IDs have been temporarily disabled. If we end up supporting dataframe indices, we'll probably want to modify to test for those. If not, we can probably get rid of them unless there's a reason to test array indices (which I assume would require remaking the neighbor csvs).

Lastly, this adds some very basic tests to make sure all the estimators can `fit` and `predict` with continuous multioutput data. I'm assuming those will be redundant with the `sklearn.utils.estimator_checks`, so we may remove them at that time or alternatively expand the tests to make sure the predictions are accurate (in which case they'd probably move into the port tests).